### PR TITLE
Add ParamEdit Plus to more modify tabs

### DIFF
--- a/ParamEditPlus.py
+++ b/ParamEditPlus.py
@@ -42,6 +42,14 @@ sheet_cmd['toolbar_panel_id'] = 'SheetMetalModifyPanel'
 pcb_cmd['toolbar_panel_id'] = 'PCBModifyPanel'
 sketch_cmd['toolbar_panel_id'] = 'SketchModifyPanel'
 
+solid_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Solid'
+surface_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Surface'
+mesh_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Mesh'
+form_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Form'
+sheet_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Sheet'
+pcb_cmd['cmd_id'] = 'cmdID_ParamEditPlus_PCB'
+sketch_cmd['cmd_id'] = 'cmdID_ParamEditPlus_Sketch'
+
 command_definitions.append(solid_cmd)
 command_definitions.append(surface_cmd)
 command_definitions.append(mesh_cmd)

--- a/ParamEditPlus.py
+++ b/ParamEditPlus.py
@@ -8,13 +8,14 @@
 
 # Importing sample Fusion Command
 # Could import multiple Command definitions here
+import copy
 from .ParamEditPlusCommand import ParamEditPlusCommand
 
 commands = []
 command_definitions = []
 
 # Define parameters for vent maker command
-cmd = {
+base_cmd = {
     'cmd_name'        : 'ParamEdit Plus',
     'cmd_description' : 'Enables you to edit all User Parameters (extended)',
     'cmd_resources'   : './resources',
@@ -23,7 +24,31 @@ cmd = {
     'toolbar_panel_id': 'SolidModifyPanel',
     'class'           : ParamEditPlusCommand
 }
-command_definitions.append(cmd)
+
+solid_cmd = copy.deepcopy(base_cmd)
+surface_cmd = copy.deepcopy(base_cmd)
+mesh_cmd = copy.deepcopy(base_cmd)
+form_cmd = copy.deepcopy(base_cmd)
+sheet_cmd = copy.deepcopy(base_cmd)
+plastic_cmd = copy.deepcopy(base_cmd)
+pcb_cmd = copy.deepcopy(base_cmd)
+sketch_cmd = copy.deepcopy(base_cmd)
+
+solid_cmd['toolbar_panel_id'] = 'SolidModifyPanel'
+surface_cmd['toolbar_panel_id'] = 'SurfaceModifyPanel'
+mesh_cmd['toolbar_panel_id'] = 'ParaMeshModifyPanel'
+form_cmd['toolbar_panel_id'] = 'TSplineModifyPanel'
+sheet_cmd['toolbar_panel_id'] = 'SheetMetalModifyPanel'
+pcb_cmd['toolbar_panel_id'] = 'PCBModifyPanel'
+sketch_cmd['toolbar_panel_id'] = 'SketchModifyPanel'
+
+command_definitions.append(solid_cmd)
+command_definitions.append(surface_cmd)
+command_definitions.append(mesh_cmd)
+command_definitions.append(form_cmd)
+command_definitions.append(sheet_cmd)
+command_definitions.append(pcb_cmd)
+command_definitions.append(sketch_cmd)
 
 # Set to True to display various useful messages when debugging your app
 debug = False


### PR DESCRIPTION
Adds the "ParamEdit Plus" button to more modify toolbars in the solid design section.

Suggested from issue #6.